### PR TITLE
feat(sidebar): hide empty platforms by default with toggle

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -6,6 +6,8 @@ import {
   Layers,
   Radar,
   Store,
+  Eye,
+  EyeOff,
   ChevronLeft,
   ChevronRight,
 } from "lucide-react";
@@ -76,6 +78,7 @@ function NavItem({
 // ─── Sidebar ────────────────────────────────────────────────────────────────
 
 export function Sidebar() {
+  const SHOW_ALL_PLATFORMS_KEY = "skills-manage:show-all-platforms";
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const { t } = useTranslation();
@@ -88,14 +91,36 @@ export function Sidebar() {
   const loadDiscoveredSkills = useDiscoverStore((s) => s.loadDiscoveredSkills);
 
   const [expanded, setExpanded] = useState(true);
+  const [showAllPlatforms, setShowAllPlatforms] = useState(() => {
+    try {
+      return window.localStorage.getItem(SHOW_ALL_PLATFORMS_KEY) === "true";
+    } catch {
+      return false;
+    }
+  });
 
   useEffect(() => {
     loadCollections();
     loadDiscoveredSkills();
   }, [loadCollections, loadDiscoveredSkills]);
 
+  function toggleShowAllPlatforms() {
+    setShowAllPlatforms((previous) => {
+      const next = !previous;
+      try {
+        window.localStorage.setItem(SHOW_ALL_PLATFORMS_KEY, String(next));
+      } catch {
+        // Ignore storage failures and keep the in-memory preference.
+      }
+      return next;
+    });
+  }
+
   const platformAgents = agents.filter(
-    (a) => a.id !== "central" && a.is_enabled
+    (a) =>
+      a.id !== "central" &&
+      a.is_enabled &&
+      (showAllPlatforms || (skillsByAgent[a.id] ?? 0) > 0)
   );
   const lobsterAgents = platformAgents.filter((a) => a.category === "lobster");
   const codingAgents = platformAgents.filter((a) => a.category !== "lobster");
@@ -246,6 +271,32 @@ export function Sidebar() {
               </>
             )}
           </>
+        )}
+
+        {!isLoading && (
+          <div className={cn(
+            "pt-2",
+            expanded ? "px-1" : "flex justify-center"
+          )}>
+            <button
+              onClick={toggleShowAllPlatforms}
+              title={showAllPlatforms ? t("sidebar.hideEmptyPlatforms") : t("sidebar.showAllPlatforms")}
+              aria-label={showAllPlatforms ? t("sidebar.hideEmptyPlatforms") : t("sidebar.showAllPlatforms")}
+              className={cn(
+                "cursor-pointer rounded-md text-muted-foreground transition-colors hover:bg-primary/10 hover:text-primary",
+                expanded
+                  ? "flex w-full items-center gap-2 px-2.5 py-1.5 text-xs text-left"
+                  : "p-2"
+              )}
+            >
+              {showAllPlatforms ? <EyeOff className="size-4 shrink-0" /> : <Eye className="size-4 shrink-0" />}
+              {expanded && (
+                <span className="truncate">
+                  {showAllPlatforms ? t("sidebar.hideEmptyPlatforms") : t("sidebar.showAllPlatforms")}
+                </span>
+              )}
+            </button>
+          </div>
         )}
       </div>
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -38,7 +38,9 @@
     "discovered": "Discovered",
     "rescan": "Re-scan...",
     "categoryLobster": "Lobster",
-    "categoryCoding": "Coding"
+    "categoryCoding": "Coding",
+    "showAllPlatforms": "Show all platforms",
+    "hideEmptyPlatforms": "Hide empty platforms"
   },
   "platform": {
     "searchPlaceholder": "Search skills...",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -38,7 +38,9 @@
     "discovered": "项目技能库",
     "rescan": "重新扫描...",
     "categoryLobster": "龙虾类",
-    "categoryCoding": "编程类"
+    "categoryCoding": "编程类",
+    "showAllPlatforms": "显示所有平台",
+    "hideEmptyPlatforms": "隐藏空平台"
   },
   "platform": {
     "searchPlaceholder": "搜索技能...",

--- a/src/test/Sidebar.test.tsx
+++ b/src/test/Sidebar.test.tsx
@@ -108,6 +108,7 @@ function renderSidebar(initialPath = "/central") {
 describe("Sidebar", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.localStorage?.clear?.();
     // Default: collection store returns empty state.
     vi.mocked(useCollectionStore).mockImplementation((selector) =>
       selector(defaultCollectionState)
@@ -235,6 +236,42 @@ describe("Sidebar", () => {
     expect(screen.queryByRole("button", { name: /Claude Code/ })).not.toBeInTheDocument();
   });
 
+  it("hides agents with zero skills by default", () => {
+    vi.mocked(usePlatformStore).mockReturnValue({
+      ...defaultStoreState,
+      skillsByAgent: {
+        "claude-code": 0,
+        cursor: 3,
+        central: 10,
+      },
+    });
+    render(
+      <MemoryRouter>
+        <Sidebar />
+      </MemoryRouter>
+    );
+    expect(screen.queryByRole("button", { name: /Claude Code/ })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Cursor/ })).toBeInTheDocument();
+  });
+
+  it("shows hidden agents after clicking toggle", () => {
+    vi.mocked(usePlatformStore).mockReturnValue({
+      ...defaultStoreState,
+      skillsByAgent: {
+        "claude-code": 0,
+        cursor: 3,
+        central: 10,
+      },
+    });
+    render(
+      <MemoryRouter>
+        <Sidebar />
+      </MemoryRouter>
+    );
+    fireEvent.click(screen.getByRole("button", { name: "显示所有平台" }));
+    expect(screen.getByRole("button", { name: /Claude Code/ })).toBeInTheDocument();
+  });
+
   // ── Navigation ────────────────────────────────────────────────────────────
 
   it("platform buttons are clickable", () => {
@@ -292,6 +329,11 @@ describe("Sidebar", () => {
   it("renders Discover entry in sidebar", () => {
     renderSidebar();
     expect(screen.getByRole("button", { name: "项目技能库" })).toBeInTheDocument();
+  });
+
+  it("renders show all platforms toggle", () => {
+    renderSidebar();
+    expect(screen.getByRole("button", { name: "显示所有平台" })).toBeInTheDocument();
   });
 
   // ── Collapse Toggle ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem
The sidebar currently shows many platform entries even when no skills were scanned for them. This makes the navigation noisy on a fresh setup or on machines where only a few tools are actually in use.
## Solution
This change hides sidebar platform entries with zero scanned skills by default, and adds a toggle so users can still reveal all platforms when needed.
## What changed
- filter sidebar platform entries using `skillsByAgent`
- keep `central` behavior unchanged
- add a sidebar toggle to switch between:
  - showing only platforms with scanned skills
  - showing all platforms
- persist the toggle preference in `localStorage`
- add/update i18n strings in both English and Chinese
- add sidebar tests covering:
  - hidden zero-skill platforms by default
  - toggle behavior
  - toggle rendering
## Why this approach
I kept the change scoped to the sidebar only.
Other views and dialogs still show the full agent/platform list, so this improves sidebar clarity without changing install flows, discover flows, or other selection UIs.
## Validation
Ran locally with Node LTS / Node 20:
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec vitest run src/test/Sidebar.test.tsx`
- `npx -y node@20 ./node_modules/vitest/vitest.mjs run`
- `cd src-tauri && cargo test`
- `cd src-tauri && cargo clippy -- -D warnings`
## Tradeoffs / follow-up
- The “empty” check is currently based on `skillsByAgent[agent.id] ?? 0`
- This PR does not change other places that list platforms/agents
- I did not add a persistence-specific test for the `localStorage` preference yet
## Notes
- naming follows existing UI conventions such as `platformStore` and `/platform/:agentId`
- the earlier full test failure under local Node 25 was environment-specific (`globalThis.localStorage` behavior) and does not reproduce under Node LTS
- This change affects sidebar behavior only.  
<img width="208" height="279" alt="Screenshot 2026-04-23 at 22 47 28" src="https://github.com/user-attachments/assets/cd099167-1348-42a8-9a09-39a97faaae01" />
