### PR TITLE
feat(ai-settings): per-provider config, protocol selector, connection test, and i18n

### DIFF
--- a/src-tauri/src/commands/marketplace.rs
+++ b/src-tauri/src/commands/marketplace.rs
@@ -589,6 +589,31 @@ fn detect_explanation_api_protocol(api_url: &str) -> ExplanationApiProtocol {
     ExplanationApiProtocol::Unknown
 }
 
+/// Resolve API protocol: explicit user preference overrides URL auto-detection.
+fn resolve_api_protocol(
+    api_url: &str,
+    explicit_protocol: Option<&str>,
+) -> ExplanationApiProtocol {
+    match explicit_protocol {
+        Some("openai") => ExplanationApiProtocol::OpenAiCompatible,
+        Some("anthropic") => ExplanationApiProtocol::AnthropicCompatible,
+        _ => detect_explanation_api_protocol(api_url),
+    }
+}
+
+fn resolve_custom_url(raw_url: &str, protocol: &ExplanationApiProtocol) -> String {
+    let trimmed = raw_url.trim();
+    if !trimmed.ends_with("/v1") {
+        return trimmed.to_string();
+    }
+    match protocol {
+        ExplanationApiProtocol::OpenAiCompatible => trimmed.to_string() + "/chat/completions",
+        ExplanationApiProtocol::AnthropicCompatible | ExplanationApiProtocol::Unknown => {
+            trimmed.to_string() + "/messages"
+        }
+    }
+}
+
 /// Error kind for AI explanation network failures, used by the frontend
 /// to render targeted UI (friendly summary + expandable details).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -696,26 +721,15 @@ fn format_reqwest_error(e: &reqwest::Error) -> String {
 
 #[tauri::command]
 pub async fn explain_skill(state: State<'_, AppState>, content: String) -> Result<String, String> {
-    // Read dynamic provider settings
-    async fn get_setting(pool: &crate::db::DbPool, key: &str) -> Option<String> {
-        sqlx::query_scalar::<_, String>("SELECT value FROM settings WHERE key = ?")
-            .bind(key)
-            .fetch_optional(pool)
-            .await
-            .ok()
-            .flatten()
-            .filter(|v| !v.trim().is_empty())
-    }
-
-    let api_key = get_setting(&state.db, "ai_api_key")
+    let api_key = get_provider_setting(&state.db, "ai_api_key")
         .await
         .ok_or_else(|| "请先在设置中配置 AI API Key".to_string())?;
 
-    let api_url = get_setting(&state.db, "ai_api_url")
+    let api_url = get_provider_setting(&state.db, "ai_api_url")
         .await
         .unwrap_or_else(|| "https://api.anthropic.com/v1/messages".to_string());
 
-    let model = get_setting(&state.db, "ai_model")
+    let model = get_provider_setting(&state.db, "ai_model")
         .await
         .unwrap_or_else(|| "claude-sonnet-4-20250514".to_string());
 
@@ -726,7 +740,6 @@ pub async fn explain_skill(state: State<'_, AppState>, content: String) -> Resul
         .build()
         .map_err(|e| e.to_string())?;
 
-    // Truncate content if too long
     let truncated = if content.len() > 8000 {
         format!("{}...\n\n(内容已截断)", &content[..8000])
     } else {
@@ -747,9 +760,12 @@ pub async fn explain_skill(state: State<'_, AppState>, content: String) -> Resul
         }],
     };
 
-    let protocol = detect_explanation_api_protocol(&api_url);
+    let explicit_protocol_opt = get_provider_setting(&state.db, "ai_protocol").await;
+    let explicit_protocol = explicit_protocol_opt.as_deref();
+    let protocol = resolve_api_protocol(&api_url, explicit_protocol);
+    let resolved_url = resolve_custom_url(&api_url, &protocol);
     let mut req_builder = client
-        .post(&api_url)
+        .post(&resolved_url)
         .header("content-type", "application/json");
 
     match protocol {
@@ -809,6 +825,86 @@ pub async fn explain_skill(state: State<'_, AppState>, content: String) -> Resul
     }
 
     Err(format!("无法解析响应: {}", &body[..body.len().min(500)]))
+}
+
+// ─── Test AI Connection ─────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn test_ai_connection(state: State<'_, AppState>) -> Result<String, String> {
+    let api_key = get_provider_setting(&state.db, "ai_api_key")
+        .await
+        .ok_or_else(|| "请先在设置中配置 AI API Key".to_string())?;
+
+    let api_url = get_provider_setting(&state.db, "ai_api_url")
+        .await
+        .unwrap_or_else(|| "https://api.anthropic.com/v1/messages".to_string());
+
+    let model = get_provider_setting(&state.db, "ai_model")
+        .await
+        .unwrap_or_else(|| "claude-sonnet-4-20250514".to_string());
+
+    let client = reqwest::Client::builder()
+        .user_agent("skills-manage/0.9.1")
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let request = serde_json::json!({
+        "model": model,
+        "max_tokens": 1,
+        "messages": [{
+            "role": "user",
+            "content": "OK"
+        }]
+    });
+
+    let explicit_protocol_opt = get_provider_setting(&state.db, "ai_protocol").await;
+    let explicit_protocol = explicit_protocol_opt.as_deref();
+    let protocol = resolve_api_protocol(&api_url, explicit_protocol);
+    let resolved_url = resolve_custom_url(&api_url, &protocol);
+    let mut req_builder = client
+        .post(&resolved_url)
+        .header("content-type", "application/json");
+
+    match protocol {
+        ExplanationApiProtocol::AnthropicCompatible | ExplanationApiProtocol::Unknown => {
+            req_builder = req_builder
+                .header("x-api-key", &api_key)
+                .header("anthropic-version", "2023-06-01");
+        }
+        ExplanationApiProtocol::OpenAiCompatible => {
+            req_builder = req_builder.header("authorization", format!("Bearer {}", api_key));
+        }
+    }
+
+    let resp = req_builder
+        .json(&request)
+        .send()
+        .await
+        .map_err(|e| format!("API 请求失败: {}", format_reqwest_error(&e)))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(format!("API 返回错误 {}: {}", status, body));
+    }
+
+    // Parse and check response body — just enough to confirm it's a valid API response
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| format!("读取响应失败: {}", e))?;
+
+    // Accept either Anthropic or OpenAI response shape
+    let val: serde_json::Value = serde_json::from_str(&body)
+        .map_err(|_| format!("无法解析响应: {}", &body[..body.len().min(200)]))?;
+
+    if val.get("content").is_some() || val.get("choices").is_some() {
+        Ok("Connection OK".to_string())
+    } else {
+        Err(format!("无法识别的响应格式: {}", &body[..body.len().min(200)]))
+    }
 }
 
 // ─── Streaming AI Explanation ────────────────────────────────────────────────
@@ -938,6 +1034,12 @@ async fn get_ai_setting(pool: &crate::db::DbPool, key: &str) -> Option<String> {
         .filter(|v| !v.trim().is_empty())
 }
 
+async fn get_provider_setting(pool: &crate::db::DbPool, key: &str) -> Option<String> {
+    let provider = get_ai_setting(pool, "ai_provider").await.unwrap_or_default();
+    let suffixed = format!("{}__{}", key, provider);
+    get_ai_setting(pool, &suffixed).await
+}
+
 /// Helper: truncate skill content to 8000 chars.
 fn truncate_content(content: &str) -> String {
     if content.len() > 8000 {
@@ -1047,15 +1149,15 @@ async fn do_explain_skill_stream(
     content: &str,
     lang: &str,
 ) -> Result<(), String> {
-    let api_key = get_ai_setting(pool, "ai_api_key")
+    let api_key = get_provider_setting(pool, "ai_api_key")
         .await
         .ok_or_else(|| "请先在设置中配置 AI API Key".to_string())?;
 
-    let api_url = get_ai_setting(pool, "ai_api_url")
+    let api_url = get_provider_setting(pool, "ai_api_url")
         .await
         .unwrap_or_else(|| "https://api.anthropic.com/v1/messages".to_string());
 
-    let model = get_ai_setting(pool, "ai_model")
+    let model = get_provider_setting(pool, "ai_model")
         .await
         .unwrap_or_else(|| "claude-sonnet-4-20250514".to_string());
 
@@ -1063,7 +1165,10 @@ async fn do_explain_skill_stream(
         .await
         .unwrap_or_default();
 
-    let protocol = detect_explanation_api_protocol(&api_url);
+    let explicit_protocol_opt = get_provider_setting(pool, "ai_protocol").await;
+    let explicit_protocol = explicit_protocol_opt.as_deref();
+    let protocol = resolve_api_protocol(&api_url, explicit_protocol);
+    let resolved_url = resolve_custom_url(&api_url, &protocol);
     let is_anthropic = matches!(
         protocol,
         ExplanationApiProtocol::AnthropicCompatible | ExplanationApiProtocol::Unknown
@@ -1083,12 +1188,12 @@ async fn do_explain_skill_stream(
 
     // Try primary endpoint; on connect-layer failure, try fallback once
     let resp =
-        match send_stream_request(&client, &api_url, &api_key, &body, is_anthropic, false).await {
+        match send_stream_request(&client, &resolved_url, &api_key, &body, is_anthropic, false).await {
             Ok(r) => r,
             Err(err_info) => {
                 // Only retry on connect-layer errors that are retryable
                 if err_info.retryable {
-                    if let Some(fallback_url) = get_fallback_endpoint(&provider, &api_url) {
+                    if let Some(fallback_url) = get_fallback_endpoint(&provider, &resolved_url) {
                         eprintln!(
                             "[explain] primary endpoint failed ({:?}), trying fallback: {}",
                             err_info.kind, fallback_url
@@ -1354,7 +1459,7 @@ mod tests {
         add_registry_impl, cache_skill_explanation, classify_reqwest_error,
         detect_explanation_api_protocol, format_reqwest_error, get_fallback_endpoint,
         load_cached_skill_explanation, marketplace_skills_from_candidates,
-        registry_has_cached_skills, search_marketplace_skills_impl, sync_registry_impl,
+        registry_has_cached_skills, resolve_api_protocol, resolve_custom_url, search_marketplace_skills_impl, sync_registry_impl,
         ExplanationApiProtocol, ExplanationErrorKind, RegistryCacheMetadata, RegistrySyncStatus,
         SyncRegistryOptions,
     };
@@ -1877,5 +1982,71 @@ mod tests {
         assert!(registry_has_cached_skills(&pool, &registry.id)
             .await
             .expect("cached"));
+    }
+
+    // ── resolve_api_protocol tests ─────────────────────────────────────────
+
+    #[test]
+    fn resolve_api_protocol_explicit_overrides_detection() {
+        assert_eq!(
+            resolve_api_protocol("https://example.com/v1/messages", Some("openai")),
+            ExplanationApiProtocol::OpenAiCompatible
+        );
+    }
+
+    #[test]
+    fn resolve_api_protocol_falls_back_to_detection_when_none() {
+        assert_eq!(
+            resolve_api_protocol("https://example.com/v1/messages", None),
+            ExplanationApiProtocol::AnthropicCompatible
+        );
+        assert_eq!(
+            resolve_api_protocol("https://example.com/v1/chat/completions", None),
+            ExplanationApiProtocol::OpenAiCompatible
+        );
+    }
+
+    #[test]
+    fn resolve_api_protocol_empty_string_same_as_none() {
+        assert_eq!(
+            resolve_api_protocol("https://example.com/v1/messages", Some("")),
+            ExplanationApiProtocol::AnthropicCompatible
+        );
+    }
+
+    #[test]
+    fn resolve_api_protocol_anthropic_explicit() {
+        assert_eq!(
+            resolve_api_protocol("https://example.com/v1/chat/completions", Some("anthropic")),
+            ExplanationApiProtocol::AnthropicCompatible
+        );
+    }
+
+    #[test]
+    fn resolve_custom_url_appends_path_for_v1_suffix() {
+        assert_eq!(
+            resolve_custom_url("https://api.example.com/v1", &ExplanationApiProtocol::OpenAiCompatible),
+            "https://api.example.com/v1/chat/completions"
+        );
+        assert_eq!(
+            resolve_custom_url("https://api.example.com/v1", &ExplanationApiProtocol::AnthropicCompatible),
+            "https://api.example.com/v1/messages"
+        );
+        assert_eq!(
+            resolve_custom_url("https://api.example.com/v1", &ExplanationApiProtocol::Unknown),
+            "https://api.example.com/v1/messages"
+        );
+    }
+
+    #[test]
+    fn resolve_custom_url_leaves_non_v1_unchanged() {
+        assert_eq!(
+            resolve_custom_url("https://api.example.com/v1/chat/completions", &ExplanationApiProtocol::OpenAiCompatible),
+            "https://api.example.com/v1/chat/completions"
+        );
+        assert_eq!(
+            resolve_custom_url("https://api.anthropic.com/v1/messages", &ExplanationApiProtocol::AnthropicCompatible),
+            "https://api.anthropic.com/v1/messages"
+        );
     }
 }

--- a/src-tauri/src/commands/marketplace.rs
+++ b/src-tauri/src/commands/marketplace.rs
@@ -590,10 +590,7 @@ fn detect_explanation_api_protocol(api_url: &str) -> ExplanationApiProtocol {
 }
 
 /// Resolve API protocol: explicit user preference overrides URL auto-detection.
-fn resolve_api_protocol(
-    api_url: &str,
-    explicit_protocol: Option<&str>,
-) -> ExplanationApiProtocol {
+fn resolve_api_protocol(api_url: &str, explicit_protocol: Option<&str>) -> ExplanationApiProtocol {
     match explicit_protocol {
         Some("openai") => ExplanationApiProtocol::OpenAiCompatible,
         Some("anthropic") => ExplanationApiProtocol::AnthropicCompatible,
@@ -902,7 +899,10 @@ pub async fn test_ai_connection(state: State<'_, AppState>) -> Result<String, St
     if val.get("content").is_some() || val.get("choices").is_some() {
         Ok("Connection OK".to_string())
     } else {
-        Err(format!("无法识别的响应格式: {}", &body[..body.len().min(200)]))
+        Err(format!(
+            "无法识别的响应格式: {}",
+            &body[..body.len().min(200)]
+        ))
     }
 }
 
@@ -1034,7 +1034,9 @@ async fn get_ai_setting(pool: &crate::db::DbPool, key: &str) -> Option<String> {
 }
 
 async fn get_provider_setting(pool: &crate::db::DbPool, key: &str) -> Option<String> {
-    let provider = get_ai_setting(pool, "ai_provider").await.unwrap_or_default();
+    let provider = get_ai_setting(pool, "ai_provider")
+        .await
+        .unwrap_or_default();
     let suffixed = format!("{}__{}", key, provider);
     get_ai_setting(pool, &suffixed).await
 }
@@ -1187,7 +1189,9 @@ async fn do_explain_skill_stream(
 
     // Try primary endpoint; on connect-layer failure, try fallback once
     let resp =
-        match send_stream_request(&client, &resolved_url, &api_key, &body, is_anthropic, false).await {
+        match send_stream_request(&client, &resolved_url, &api_key, &body, is_anthropic, false)
+            .await
+        {
             Ok(r) => r,
             Err(err_info) => {
                 // Only retry on connect-layer errors that are retryable
@@ -1458,9 +1462,9 @@ mod tests {
         add_registry_impl, cache_skill_explanation, classify_reqwest_error,
         detect_explanation_api_protocol, format_reqwest_error, get_fallback_endpoint,
         load_cached_skill_explanation, marketplace_skills_from_candidates,
-        registry_has_cached_skills, resolve_api_protocol, resolve_custom_url, search_marketplace_skills_impl, sync_registry_impl,
-        ExplanationApiProtocol, ExplanationErrorKind, RegistryCacheMetadata, RegistrySyncStatus,
-        SyncRegistryOptions,
+        registry_has_cached_skills, resolve_api_protocol, resolve_custom_url,
+        search_marketplace_skills_impl, sync_registry_impl, ExplanationApiProtocol,
+        ExplanationErrorKind, RegistryCacheMetadata, RegistrySyncStatus, SyncRegistryOptions,
     };
     use crate::commands::github_import::RemoteSkillCandidate;
     use crate::db;
@@ -2024,15 +2028,24 @@ mod tests {
     #[test]
     fn resolve_custom_url_appends_path_for_v1_suffix() {
         assert_eq!(
-            resolve_custom_url("https://api.example.com/v1", &ExplanationApiProtocol::OpenAiCompatible),
+            resolve_custom_url(
+                "https://api.example.com/v1",
+                &ExplanationApiProtocol::OpenAiCompatible
+            ),
             "https://api.example.com/v1/chat/completions"
         );
         assert_eq!(
-            resolve_custom_url("https://api.example.com/v1", &ExplanationApiProtocol::AnthropicCompatible),
+            resolve_custom_url(
+                "https://api.example.com/v1",
+                &ExplanationApiProtocol::AnthropicCompatible
+            ),
             "https://api.example.com/v1/messages"
         );
         assert_eq!(
-            resolve_custom_url("https://api.example.com/v1", &ExplanationApiProtocol::Unknown),
+            resolve_custom_url(
+                "https://api.example.com/v1",
+                &ExplanationApiProtocol::Unknown
+            ),
             "https://api.example.com/v1"
         );
     }
@@ -2040,11 +2053,17 @@ mod tests {
     #[test]
     fn resolve_custom_url_leaves_non_v1_unchanged() {
         assert_eq!(
-            resolve_custom_url("https://api.example.com/v1/chat/completions", &ExplanationApiProtocol::OpenAiCompatible),
+            resolve_custom_url(
+                "https://api.example.com/v1/chat/completions",
+                &ExplanationApiProtocol::OpenAiCompatible
+            ),
             "https://api.example.com/v1/chat/completions"
         );
         assert_eq!(
-            resolve_custom_url("https://api.anthropic.com/v1/messages", &ExplanationApiProtocol::AnthropicCompatible),
+            resolve_custom_url(
+                "https://api.anthropic.com/v1/messages",
+                &ExplanationApiProtocol::AnthropicCompatible
+            ),
             "https://api.anthropic.com/v1/messages"
         );
     }

--- a/src-tauri/src/commands/marketplace.rs
+++ b/src-tauri/src/commands/marketplace.rs
@@ -608,9 +608,8 @@ fn resolve_custom_url(raw_url: &str, protocol: &ExplanationApiProtocol) -> Strin
     }
     match protocol {
         ExplanationApiProtocol::OpenAiCompatible => trimmed.to_string() + "/chat/completions",
-        ExplanationApiProtocol::AnthropicCompatible | ExplanationApiProtocol::Unknown => {
-            trimmed.to_string() + "/messages"
-        }
+        ExplanationApiProtocol::AnthropicCompatible => trimmed.to_string() + "/messages",
+        ExplanationApiProtocol::Unknown => trimmed.to_string(),
     }
 }
 
@@ -2034,7 +2033,7 @@ mod tests {
         );
         assert_eq!(
             resolve_custom_url("https://api.example.com/v1", &ExplanationApiProtocol::Unknown),
-            "https://api.example.com/v1/messages"
+            "https://api.example.com/v1"
         );
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -101,6 +101,7 @@ pub fn run() {
             commands::marketplace::get_skill_explanation,
             commands::marketplace::explain_skill_stream,
             commands::marketplace::refresh_skill_explanation,
+            commands::marketplace::test_ai_connection,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/data/aiProviders.ts
+++ b/src/data/aiProviders.ts
@@ -56,7 +56,7 @@ export const AI_PROVIDERS: AiProvider[] = [
     endpoints: {
       cn: "https://api.deepseek.com/anthropic/v1/messages",
     },
-    defaultModel: "DeepSeek-V3.2",
+    defaultModel: "deepseek-v4-flash",
   },
   {
     id: "openrouter",

--- a/src/data/aiProviders.ts
+++ b/src/data/aiProviders.ts
@@ -1,5 +1,7 @@
 export type RegionId = "cn" | "intl";
 
+export type ApiProtocol = "anthropic" | "openai";
+
 export interface AiProvider {
   id: string;
   name: { zh: string; en: string };
@@ -68,9 +70,31 @@ export const AI_PROVIDERS: AiProvider[] = [
   {
     id: "custom",
     name: { zh: "自定义", en: "Custom" },
-    regions: ["cn", "intl"],
+    regions: ["intl"],
     endpoints: {},
     defaultModel: "",
+  },
+];
+
+export const API_PROTOCOLS: {
+  id: ApiProtocol | "";
+  label: { zh: string; en: string };
+  desc: { zh: string; en: string };
+}[] = [
+  {
+    id: "",
+    label: { zh: "自动", en: "Auto" },
+    desc: { zh: "根据 URL 自动检测", en: "Auto-detect from URL" },
+  },
+  {
+    id: "anthropic",
+    label: { zh: "Anthropic", en: "Anthropic" },
+    desc: { zh: "x-api-key 认证", en: "x-api-key auth" },
+  },
+  {
+    id: "openai",
+    label: { zh: "OpenAI", en: "OpenAI" },
+    desc: { zh: "Bearer Token 认证", en: "Bearer token auth" },
   },
 ];
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -298,7 +298,41 @@
     },
     "language": "Language",
     "chinese": "中文",
-    "english": "English"
+    "english": "English",
+    "aiProviderTitle": "AI Provider",
+    "aiProviderDesc": "Configure AI service for skill explanation. Supports Anthropic & OpenAI-compatible APIs.",
+    "aiProviderLabel": "Provider",
+    "aiProvider": {
+      "claude": "Claude",
+      "glm": "Zhipu GLM",
+      "minimax": "MiniMax",
+      "kimi": "Kimi",
+      "deepseek": "DeepSeek",
+      "openrouter": "OpenRouter",
+      "custom": "Custom"
+    },
+    "aiRegionLabel": "Region",
+    "aiRegion": {
+      "cn": "China",
+      "intl": "International"
+    },
+    "aiApiKeyLabel": "API Key",
+    "aiModelLabel": "Model",
+    "aiModelPlaceholder": "Model name",
+    "aiApiFormatLabel": "API Format",
+    "aiProtocol": {
+      "auto": "Auto",
+      "anthropic": "Anthropic",
+      "openai": "OpenAI"
+    },
+    "aiApiUrlLabel": "API URL",
+    "aiTestButton": "Test Connection",
+    "aiTestTesting": "Testing...",
+    "aiTestSuccess": "Connection OK",
+    "aiTestConnectionVerified": "Connection verified",
+    "aiTestEnterUrl": "Please enter API URL first",
+    "aiTestDetails": "Details",
+    "aiTestRegionTip": "Tip: Try switching the region endpoint above (current: {{region}})"
   },
   "addDir": {
     "title": "Add Project Directory",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -298,7 +298,41 @@
     },
     "language": "语言",
     "chinese": "中文",
-    "english": "English"
+    "english": "English",
+    "aiProviderTitle": "AI 提供商",
+    "aiProviderDesc": "为技能解释功能配置 AI 服务，支持 Anthropic 和 OpenAI 兼容接口。",
+    "aiProviderLabel": "提供商",
+    "aiProvider": {
+      "claude": "Claude",
+      "glm": "智谱 GLM",
+      "minimax": "MiniMax",
+      "kimi": "Kimi",
+      "deepseek": "DeepSeek",
+      "openrouter": "OpenRouter",
+      "custom": "自定义"
+    },
+    "aiRegionLabel": "区域",
+    "aiRegion": {
+      "cn": "国内",
+      "intl": "国际"
+    },
+    "aiApiKeyLabel": "API Key",
+    "aiModelLabel": "模型",
+    "aiModelPlaceholder": "模型名称",
+    "aiApiFormatLabel": "API 格式",
+    "aiProtocol": {
+      "auto": "自动",
+      "anthropic": "Anthropic",
+      "openai": "OpenAI"
+    },
+    "aiApiUrlLabel": "API URL",
+    "aiTestButton": "测试连接",
+    "aiTestTesting": "测试中...",
+    "aiTestSuccess": "连接成功",
+    "aiTestConnectionVerified": "连接验证通过",
+    "aiTestEnterUrl": "请先输入 API URL",
+    "aiTestDetails": "查看详情",
+    "aiTestRegionTip": "提示：可在上方切换区域端点后重试（当前：{{region}}）"
   },
   "addDir": {
     "title": "添加项目目录",

--- a/src/pages/SettingsView.tsx
+++ b/src/pages/SettingsView.tsx
@@ -234,6 +234,7 @@ export function SettingsView() {
   const [aiCustomUrl, setAiCustomUrl] = useState("");
   const [aiProtocol, setAiProtocol] = useState<ApiProtocol | "">("");
   const [aiLoaded, setAiLoaded] = useState(false);
+  const [hasUserInteracted, setHasUserInteracted] = useState(false);
   const [providerLoading, setProviderLoading] = useState(false);
 
   // Load AI settings on mount
@@ -263,9 +264,9 @@ export function SettingsView() {
     })();
   }, []);
 
-  // Save AI settings when changed
+  // Save AI settings when changed (only after user interaction)
   useEffect(() => {
-    if (!aiLoaded) return;
+    if (!aiLoaded || !hasUserInteracted) return;
     const save = async () => {
       try {
         await invoke("set_setting", { key: "ai_provider", value: aiProvider });
@@ -280,12 +281,13 @@ export function SettingsView() {
       } catch { /* ignore */ }
     };
     save();
-  }, [aiProvider, aiRegion, aiApiKey, aiModel, aiCustomUrl, aiProtocol, aiLoaded]);
+  }, [aiProvider, aiRegion, aiApiKey, aiModel, aiCustomUrl, aiProtocol, aiLoaded, hasUserInteracted]);
 
   // When provider or region changes, update model to default
   async function handleProviderChange(id: string) {
     if (providerLoading) return;
     setProviderLoading(true);
+    setAiLoaded(false);           // block save until new config is loaded
     setAiProvider(id);
     setAiTestResult(null);
     const p = AI_PROVIDERS.find((x) => x.id === id);
@@ -309,6 +311,7 @@ export function SettingsView() {
       setAiCustomUrl("");
       setAiProtocol("");
     } finally {
+      setAiLoaded(true);
       setProviderLoading(false);
     }
   }
@@ -643,7 +646,8 @@ export function SettingsView() {
                 <label className="text-xs text-muted-foreground mb-2 block">{t("settings.aiProviderLabel")}</label>
                 <div className="flex flex-wrap gap-1.5">
                   {AI_PROVIDERS.map((p) => (
-                    <button key={p.id} disabled={providerLoading} onClick={() => handleProviderChange(p.id)} className={`px-3 py-1.5 rounded-md text-xs transition-colors cursor-pointer border ${aiProvider === p.id ? "bg-primary/15 border-primary text-foreground font-medium" : "border-border bg-background text-muted-foreground hover:border-primary/40 hover:bg-hover-bg/10"}`}>
+                    <button key={p.id} disabled={providerLoading} onClick={() => { setHasUserInteracted(true); handleProviderChange(p.id); }} className={`px-3 py-1.5 rounded-md text-xs transition-colors cursor-pointer border ${aiProvider === p.id ? "bg-primary/15 border-primary text-foreground font-medium" : "border-border bg-background text-muted-foreground hover:border-primary/40 hover:bg-hover-bg/10"} ${providerLoading ? "opacity-50 cursor-not-allowed" : ""}`}>
+                      {providerLoading && aiProvider === p.id ? <Loader2 className="size-3 animate-spin inline mr-1" /> : null}
                       {t(`settings.aiProvider.${p.id}`)}
                     </button>
                   ))}
@@ -654,7 +658,7 @@ export function SettingsView() {
                   <label className="text-xs text-muted-foreground mb-2 block">{t("settings.aiRegionLabel")}</label>
                   <div className="flex gap-1.5">
                     {currentProvider.regions.map((r) => (
-                      <button key={r} onClick={() => setAiRegion(r)} className={`px-3 py-1.5 rounded-md text-xs transition-colors cursor-pointer border ${aiRegion === r ? "bg-primary/15 border-primary text-foreground font-medium" : "border-border bg-background text-muted-foreground hover:border-primary/40"}`}>
+                      <button key={r} onClick={() => { setHasUserInteracted(true); setAiRegion(r); }} className={`px-3 py-1.5 rounded-md text-xs transition-colors cursor-pointer border ${aiRegion === r ? "bg-primary/15 border-primary text-foreground font-medium" : "border-border bg-background text-muted-foreground hover:border-primary/40"}`}>
                         {t(`settings.aiRegion.${r}`)}
                       </button>
                     ))}
@@ -664,7 +668,7 @@ export function SettingsView() {
               <div>
                 <label className="text-xs text-muted-foreground mb-1 block">{t("settings.aiApiKeyLabel")}</label>
                 <div className="relative">
-                  <Input type={showKey ? "text" : "password"} placeholder="sk-..." value={aiApiKey} onChange={(e) => setAiApiKey(e.target.value)} className="pr-9" />
+                  <Input type={showKey ? "text" : "password"} placeholder="sk-..." value={aiApiKey} onChange={(e) => { setHasUserInteracted(true); setAiApiKey(e.target.value); }} className="pr-9" />
                   <button type="button" onClick={() => setShowKey(!showKey)} className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground">
                     {showKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                   </button>
@@ -672,14 +676,14 @@ export function SettingsView() {
               </div>
               <div>
                 <label className="text-xs text-muted-foreground mb-1 block">{t("settings.aiModelLabel")}</label>
-                <Input placeholder={t("settings.aiModelPlaceholder")} value={aiModel} onChange={(e) => setAiModel(e.target.value)} />
+                <Input placeholder={t("settings.aiModelPlaceholder")} value={aiModel} onChange={(e) => { setHasUserInteracted(true); setAiModel(e.target.value); }} />
               </div>
               {aiProvider === "custom" && (
                 <div>
                   <label className="text-xs text-muted-foreground mb-2 block">{t("settings.aiApiFormatLabel")}</label>
                   <div className="flex flex-wrap gap-1.5">
                     {API_PROTOCOLS.map((proto) => (
-                      <button key={proto.id} onClick={() => setAiProtocol(proto.id as ApiProtocol | "")} className={`px-3 py-1.5 rounded-md text-xs transition-colors cursor-pointer border ${aiProtocol === proto.id ? "bg-primary/15 border-primary text-foreground font-medium" : "border-border bg-background text-muted-foreground hover:border-primary/40 hover:bg-hover-bg/10"}`}>
+                      <button key={proto.id} onClick={() => { setHasUserInteracted(true); setAiProtocol(proto.id as ApiProtocol | ""); }} className={`px-3 py-1.5 rounded-md text-xs transition-colors cursor-pointer border ${aiProtocol === proto.id ? "bg-primary/15 border-primary text-foreground font-medium" : "border-border bg-background text-muted-foreground hover:border-primary/40 hover:bg-hover-bg/10"}`}>
                         {t(`settings.aiProtocol.${proto.id || "auto"}`)}
                       </button>
                     ))}
@@ -689,7 +693,7 @@ export function SettingsView() {
               {aiProvider === "custom" && (
                 <div>
                   <label className="text-xs text-muted-foreground mb-1 block">{t("settings.aiApiUrlLabel")}</label>
-                  <Input placeholder="https://..." value={aiCustomUrl} onChange={(e) => setAiCustomUrl(e.target.value)} />
+                  <Input placeholder="https://..." value={aiCustomUrl} onChange={(e) => { setHasUserInteracted(true); setAiCustomUrl(e.target.value); }} />
                 </div>
               )}
               <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">

--- a/src/pages/SettingsView.tsx
+++ b/src/pages/SettingsView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Plus, Trash2, Pencil, Loader2, FolderOpen, Cpu, Info, Database, Globe, Palette, Droplets, Bot, ChevronDown, ChevronRight, KeyRound } from "lucide-react";
+import { Plus, Trash2, Pencil, Loader2, FolderOpen, Cpu, Info, Database, Globe, Palette, Droplets, Bot, ChevronDown, ChevronRight, KeyRound, Eye, EyeOff, Check } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
@@ -22,7 +22,7 @@ import { AddDirectoryDialog } from "@/components/settings/AddDirectoryDialog";
 import { PlatformDialog } from "@/components/settings/PlatformDialog";
 import { Input } from "@/components/ui/input";
 import { AgentWithStatus, ScanDirectory } from "@/types";
-import { AI_PROVIDERS, REGION_LABELS, RegionId } from "@/data/aiProviders";
+import { AI_PROVIDERS, RegionId, ApiProtocol, API_PROTOCOLS } from "@/data/aiProviders";
 import { deriveHomeDir, formatPathForDisplay, joinPathForDisplay } from "@/lib/path";
 
 // ─── App constants ────────────────────────────────────────────────────────────
@@ -61,6 +61,20 @@ const CTP_VAR_MAP: Record<CatppuccinAccent, string> = {
 };
 
 const FLAVOR_ORDER: CatppuccinFlavor[] = ["mocha", "macchiato", "frappe", "latte"];
+
+/** Expand a raw custom base URL to its full endpoint based on protocol. */
+function resolveCustomUrl(rawUrl: string, protocol: ApiProtocol | ""): string {
+  const trimmed = rawUrl.trim();
+  if (!trimmed || !trimmed.endsWith("/v1")) return trimmed;
+  switch (protocol) {
+    case "openai":
+      return trimmed + "/chat/completions";
+    case "anthropic":
+      return trimmed + "/messages";
+    default:
+      return trimmed;
+  }
+}
 
 // ─── ScanDirectoryRow ─────────────────────────────────────────────────────────
 
@@ -215,9 +229,12 @@ export function SettingsView() {
   const [aiProvider, setAiProvider] = useState("claude");
   const [aiRegion, setAiRegion] = useState<RegionId>("intl");
   const [aiApiKey, setAiApiKey] = useState("");
+  const [showKey, setShowKey] = useState(false);
   const [aiModel, setAiModel] = useState("");
   const [aiCustomUrl, setAiCustomUrl] = useState("");
+  const [aiProtocol, setAiProtocol] = useState<ApiProtocol | "">("");
   const [aiLoaded, setAiLoaded] = useState(false);
+  const [providerLoading, setProviderLoading] = useState(false);
 
   // Load AI settings on mount
   useEffect(() => {
@@ -225,14 +242,22 @@ export function SettingsView() {
       try {
         const provider = await invoke<string | null>("get_setting", { key: "ai_provider" });
         const region = await invoke<string | null>("get_setting", { key: "ai_region" });
-        const key = await invoke<string | null>("get_setting", { key: "ai_api_key" });
-        const model = await invoke<string | null>("get_setting", { key: "ai_model" });
-        const url = await invoke<string | null>("get_setting", { key: "ai_api_url" });
         if (provider) setAiProvider(provider);
         if (region) setAiRegion(region as RegionId);
-        if (key) setAiApiKey(key);
-        if (model) setAiModel(model);
-        if (url) setAiCustomUrl(url);
+        if (provider) {
+          const key = await invoke<string | null>("get_setting", { key: `ai_api_key__${provider}` });
+          const model = await invoke<string | null>("get_setting", { key: `ai_model__${provider}` });
+          const baseUrl = await invoke<string | null>("get_setting", { key: `ai_custom_base_url__${provider}` });
+          const protocol = await invoke<string | null>("get_setting", { key: `ai_protocol__${provider}` });
+          if (key) setAiApiKey(key);
+          if (model) setAiModel(model);
+          else {
+            const p = AI_PROVIDERS.find((x) => x.id === provider);
+            if (p) setAiModel(p.defaultModel);
+          }
+          if (baseUrl) setAiCustomUrl(baseUrl);
+          if (protocol) setAiProtocol(protocol as ApiProtocol);
+        }
       } catch { /* first run, no settings yet */ }
       setAiLoaded(true);
     })();
@@ -245,38 +270,62 @@ export function SettingsView() {
       try {
         await invoke("set_setting", { key: "ai_provider", value: aiProvider });
         await invoke("set_setting", { key: "ai_region", value: aiRegion });
-        await invoke("set_setting", { key: "ai_api_key", value: aiApiKey });
-        await invoke("set_setting", { key: "ai_model", value: aiModel });
-        // Compute and save the actual API URL
+        await invoke("set_setting", { key: `ai_api_key__${aiProvider}`, value: aiApiKey });
+        await invoke("set_setting", { key: `ai_model__${aiProvider}`, value: aiModel });
         const p = AI_PROVIDERS.find((x) => x.id === aiProvider);
-        const url = aiProvider === "custom" ? aiCustomUrl : (p?.endpoints[aiRegion] ?? "");
-        await invoke("set_setting", { key: "ai_api_url", value: url });
+        const url = aiProvider === "custom" ? resolveCustomUrl(aiCustomUrl, aiProtocol) : (p?.endpoints[aiRegion] ?? "");
+        await invoke("set_setting", { key: `ai_api_url__${aiProvider}`, value: url });
+        await invoke("set_setting", { key: `ai_custom_base_url__${aiProvider}`, value: aiCustomUrl });
+        await invoke("set_setting", { key: `ai_protocol__${aiProvider}`, value: aiProtocol });
       } catch { /* ignore */ }
     };
     save();
-  }, [aiProvider, aiRegion, aiApiKey, aiModel, aiCustomUrl, aiLoaded]);
+  }, [aiProvider, aiRegion, aiApiKey, aiModel, aiCustomUrl, aiProtocol, aiLoaded]);
 
   // When provider or region changes, update model to default
-  function handleProviderChange(id: string) {
+  async function handleProviderChange(id: string) {
+    if (providerLoading) return;
+    setProviderLoading(true);
     setAiProvider(id);
+    setAiTestResult(null);
     const p = AI_PROVIDERS.find((x) => x.id === id);
     if (p) {
-      setAiModel(p.defaultModel);
-      // Auto-select first available region
       if (!p.regions.includes(aiRegion)) {
         setAiRegion(p.regions[0]);
       }
+    }
+    try {
+      const key = await invoke<string | null>("get_setting", { key: `ai_api_key__${id}` });
+      const model = await invoke<string | null>("get_setting", { key: `ai_model__${id}` });
+      const protocol = await invoke<string | null>("get_setting", { key: `ai_protocol__${id}` });
+      const baseUrl = await invoke<string | null>("get_setting", { key: `ai_custom_base_url__${id}` });
+      setAiApiKey(key ?? "");
+      setAiModel(model ?? p?.defaultModel ?? "");
+      setAiProtocol(protocol ? (protocol as ApiProtocol) : "");
+      setAiCustomUrl(baseUrl ?? "");
+    } catch {
+      setAiApiKey("");
+      setAiModel(p?.defaultModel ?? "");
+      setAiCustomUrl("");
+      setAiProtocol("");
+    } finally {
+      setProviderLoading(false);
     }
   }
 
   const currentProvider = AI_PROVIDERS.find((p) => p.id === aiProvider);
   const resolvedUrl = aiProvider === "custom"
-    ? aiCustomUrl
+    ? resolveCustomUrl(aiCustomUrl, aiProtocol)
     : (currentProvider?.endpoints[aiRegion] ?? "");
-  const lang = i18n.language;
+
   const [aiTesting, setAiTesting] = useState(false);
   const [aiTestResult, setAiTestResult] = useState<{ ok: boolean; msg: string; details?: string } | null>(null);
   const [showAiTestDetails, setShowAiTestDetails] = useState(false);
+
+  // Clear stale test result when config changes
+  useEffect(() => {
+    setAiTestResult(null);
+  }, [aiApiKey, aiCustomUrl, aiProtocol, aiRegion, aiModel]);
 
   const [isAddDirOpen, setIsAddDirOpen] = useState(false);
   const [showBuiltinDirs, setShowBuiltinDirs] = useState(false);
@@ -581,9 +630,9 @@ export function SettingsView() {
             <div className="flex items-center gap-2">
               <Bot className="size-5 text-muted-foreground" />
               <div>
-                <CardTitle>{lang === "zh" ? "AI 提供商" : "AI Provider"}</CardTitle>
+                <CardTitle>{t("settings.aiProviderTitle")}</CardTitle>
                 <CardDescription className="mt-1">
-                  {lang === "zh" ? "配置用于技能解释的 AI 服务。所有提供商兼容 Anthropic API 格式。" : "Configure AI service for skill explanation. All providers use Anthropic-compatible API."}
+                  {t("settings.aiProviderDesc")}
                 </CardDescription>
               </div>
             </div>
@@ -591,85 +640,116 @@ export function SettingsView() {
           <CardContent>
             <div className="space-y-4">
               <div>
-                <label className="text-xs text-muted-foreground mb-2 block">{lang === "zh" ? "提供商" : "Provider"}</label>
+                <label className="text-xs text-muted-foreground mb-2 block">{t("settings.aiProviderLabel")}</label>
                 <div className="flex flex-wrap gap-1.5">
                   {AI_PROVIDERS.map((p) => (
-                    <button key={p.id} onClick={() => handleProviderChange(p.id)} className={`px-3 py-1.5 rounded-md text-xs transition-colors cursor-pointer border ${aiProvider === p.id ? "bg-primary/15 border-primary text-foreground font-medium" : "border-border bg-background text-muted-foreground hover:border-primary/40 hover:bg-hover-bg/10"}`}>
-                      {lang === "zh" ? p.name.zh : p.name.en}
+                    <button key={p.id} disabled={providerLoading} onClick={() => handleProviderChange(p.id)} className={`px-3 py-1.5 rounded-md text-xs transition-colors cursor-pointer border ${aiProvider === p.id ? "bg-primary/15 border-primary text-foreground font-medium" : "border-border bg-background text-muted-foreground hover:border-primary/40 hover:bg-hover-bg/10"}`}>
+                      {t(`settings.aiProvider.${p.id}`)}
                     </button>
                   ))}
                 </div>
               </div>
               {currentProvider && currentProvider.regions.length > 1 && (
                 <div>
-                  <label className="text-xs text-muted-foreground mb-2 block">{lang === "zh" ? "区域" : "Region"}</label>
+                  <label className="text-xs text-muted-foreground mb-2 block">{t("settings.aiRegionLabel")}</label>
                   <div className="flex gap-1.5">
                     {currentProvider.regions.map((r) => (
                       <button key={r} onClick={() => setAiRegion(r)} className={`px-3 py-1.5 rounded-md text-xs transition-colors cursor-pointer border ${aiRegion === r ? "bg-primary/15 border-primary text-foreground font-medium" : "border-border bg-background text-muted-foreground hover:border-primary/40"}`}>
-                        {lang === "zh" ? REGION_LABELS[r].zh : REGION_LABELS[r].en}
+                        {t(`settings.aiRegion.${r}`)}
                       </button>
                     ))}
                   </div>
                 </div>
               )}
               <div>
-                <label className="text-xs text-muted-foreground mb-1 block">API Key</label>
-                <Input type="password" placeholder="sk-..." value={aiApiKey} onChange={(e) => setAiApiKey(e.target.value)} />
+                <label className="text-xs text-muted-foreground mb-1 block">{t("settings.aiApiKeyLabel")}</label>
+                <div className="relative">
+                  <Input type={showKey ? "text" : "password"} placeholder="sk-..." value={aiApiKey} onChange={(e) => setAiApiKey(e.target.value)} className="pr-9" />
+                  <button type="button" onClick={() => setShowKey(!showKey)} className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground">
+                    {showKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </button>
+                </div>
               </div>
               <div>
-                <label className="text-xs text-muted-foreground mb-1 block">{lang === "zh" ? "模型" : "Model"}</label>
-                <Input placeholder={lang === "zh" ? "模型名称" : "Model name"} value={aiModel} onChange={(e) => setAiModel(e.target.value)} />
+                <label className="text-xs text-muted-foreground mb-1 block">{t("settings.aiModelLabel")}</label>
+                <Input placeholder={t("settings.aiModelPlaceholder")} value={aiModel} onChange={(e) => setAiModel(e.target.value)} />
               </div>
               {aiProvider === "custom" && (
                 <div>
-                  <label className="text-xs text-muted-foreground mb-1 block">API URL</label>
+                  <label className="text-xs text-muted-foreground mb-2 block">{t("settings.aiApiFormatLabel")}</label>
+                  <div className="flex flex-wrap gap-1.5">
+                    {API_PROTOCOLS.map((proto) => (
+                      <button key={proto.id} onClick={() => setAiProtocol(proto.id as ApiProtocol | "")} className={`px-3 py-1.5 rounded-md text-xs transition-colors cursor-pointer border ${aiProtocol === proto.id ? "bg-primary/15 border-primary text-foreground font-medium" : "border-border bg-background text-muted-foreground hover:border-primary/40 hover:bg-hover-bg/10"}`}>
+                        {t(`settings.aiProtocol.${proto.id || "auto"}`)}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+              {aiProvider === "custom" && (
+                <div>
+                  <label className="text-xs text-muted-foreground mb-1 block">{t("settings.aiApiUrlLabel")}</label>
                   <Input placeholder="https://..." value={aiCustomUrl} onChange={(e) => setAiCustomUrl(e.target.value)} />
                 </div>
               )}
-              <div className="flex items-center gap-3">
-                {resolvedUrl && (
-                  <div className="text-xs text-muted-foreground bg-muted/30 rounded-md px-3 py-2 font-mono truncate flex-1 min-w-0">{resolvedUrl}</div>
-                )}
-                <Button variant="outline" size="sm" disabled={aiTesting || !aiApiKey || !resolvedUrl} onClick={async () => {
-                  setAiTesting(true); setAiTestResult(null); setShowAiTestDetails(false);
-                  try {
-                    const result = await invoke<string>("explain_skill", { content: "Test connection. Reply with: OK" });
-                    setAiTestResult({ ok: true, msg: result.slice(0, 60) });
-                  } catch (err) {
-                    const raw = String(err);
-                    // Try to extract structured error from JSON-like error strings
-                    let msg = raw;
-                    let details: string | undefined;
-                    const prefix = "API 请求失败: ";
-                    if (raw.startsWith(prefix)) {
-                      const after = raw.slice(prefix.length);
-                      const nlIdx = after.indexOf("\n");
-                      if (nlIdx > 0) {
-                        msg = after.slice(nlIdx + 1);
-                        details = after.slice(0, nlIdx);
-                      } else {
-                        msg = after;
+              <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
+                <div className="min-w-0">
+                  {aiTestResult?.ok ? (
+                    <span className="inline-flex items-center gap-1.5 text-xs text-green-700 dark:text-green-400">
+                      <Check className="size-3.5" />
+                      {t("settings.aiTestConnectionVerified")}
+                    </span>
+                  ) : aiProvider === "custom" && !aiCustomUrl.trim() ? (
+                    <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+                      <Info className="size-3.5" />
+                      {t("settings.aiTestEnterUrl")}
+                    </span>
+                  ) : null}
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={aiTesting || !aiApiKey || !resolvedUrl}
+                  onClick={async () => {
+                    setAiTesting(true); setAiTestResult(null); setShowAiTestDetails(false);
+                    try {
+                      await invoke<string>("test_ai_connection");
+                      setAiTestResult({ ok: true, msg: t("settings.aiTestSuccess") });
+                    } catch (err) {
+                      const raw = String(err);
+                      let msg = raw;
+                      let details: string | undefined;
+                      const prefix = "API 请求失败: ";
+                      if (raw.startsWith(prefix)) {
+                        const after = raw.slice(prefix.length);
+                        const nlIdx = after.indexOf("\n");
+                        if (nlIdx > 0) {
+                          msg = after.slice(nlIdx + 1);
+                          details = after.slice(0, nlIdx);
+                        } else {
+                          msg = after;
+                        }
                       }
-                    }
-                    setAiTestResult({ ok: false, msg, details });
-                  }
-                  finally { setAiTesting(false); }
-                }} className="shrink-0">
+                      setAiTestResult({ ok: false, msg, details });
+                    } finally { setAiTesting(false); }
+                  }}
+                  className="shrink-0"
+                >
                   {aiTesting ? <Loader2 className="size-3.5 animate-spin" /> : <Bot className="size-3.5" />}
-                  <span>{lang === "zh" ? "测试连接" : "Test"}</span>
+                  <span>{aiTesting ? t("settings.aiTestTesting") : t("settings.aiTestButton")}</span>
                 </Button>
               </div>
-              {aiTestResult && (
-                <div className={`text-xs rounded-md px-3 py-2 space-y-1.5 ${aiTestResult.ok ? "bg-green-500/10 text-green-700 dark:text-green-400" : "bg-destructive/10 text-destructive"}`}>
-                  <p>{aiTestResult.ok ? "✓ " : "✕ "}{aiTestResult.msg}</p>
-                  {!aiTestResult.ok && aiTestResult.details && (
+              {aiTestResult && !aiTestResult.ok && (
+                <div className="rounded-md border border-destructive/20 bg-destructive/5 px-3 py-2 space-y-1.5 text-destructive text-xs">
+                  <p>{aiTestResult.msg}</p>
+                  {aiTestResult.details && (
                     <div>
                       <button
                         className="flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
                         onClick={() => setShowAiTestDetails((v) => !v)}
                       >
                         {showAiTestDetails ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
-                        {lang === "zh" ? "查看详情" : "Details"}
+                        {t("settings.aiTestDetails")}
                       </button>
                       {showAiTestDetails && (
                         <pre className="mt-1 text-[11px] leading-4 font-mono text-muted-foreground whitespace-pre-wrap break-all bg-muted/30 rounded-md p-2 max-h-32 overflow-auto">
@@ -678,11 +758,9 @@ export function SettingsView() {
                       )}
                     </div>
                   )}
-                  {!aiTestResult.ok && currentProvider && currentProvider.regions.length > 1 && (
+                  {currentProvider && currentProvider.regions.length > 1 && (
                     <p className="text-muted-foreground">
-                      {lang === "zh"
-                        ? `提示：可在上方切换区域端点后重试（当前：${REGION_LABELS[aiRegion]?.zh ?? aiRegion}）`
-                        : `Tip: Try switching the region endpoint above (current: ${REGION_LABELS[aiRegion]?.en ?? aiRegion})`}
+                      {t("settings.aiTestRegionTip", { region: t(`settings.aiRegion.${aiRegion}`) })}
                     </p>
                   )}
                 </div>


### PR DESCRIPTION
## Problem
The AI explanation feature currently uses a single global API Key / model / URL, making it impossible to switch between different AI providers without manually re-entering all settings. Additionally:
- It's very slow to verify the API connection is working before running an explanation prompt
- Custom API endpoints (e.g., OpenAI-compatible proxies) are not supported
- All UI strings in the AI settings section are hardcoded Chinese/English, inconsistent with the rest of the app
- No API Key input with show/hide toggle (click the eye icon to reveal or mask the key)
## Solution
Add a full AI Provider settings panel that supports per-provider configuration storage, explicit protocol selection for custom endpoints (including OpenAI-compatible format), and a fast connection test.
## What changed
### Backend (`src-tauri/src/commands/marketplace.rs`)
- Add `get_provider_setting()` — reads settings suffixed by provider ID (`ai_api_key__claude`, `ai_model__deepseek`, etc.)
- Add `resolve_api_protocol()` — explicit user preference overrides URL auto-detection
- Add `resolve_custom_url()` — expands `/v1` suffix to `/messages` or `/chat/completions` based on protocol
- Add `test_ai_connection` Tauri command — lightweight connection check with `max_tokens: 1`
- Update `explain_skill` and `do_explain_skill_stream` to use per-provider settings and protocol resolution
### Frontend (`src/pages/SettingsView.tsx`)
- Replace single global AI inputs with per-provider tabs
- Add provider selector (Claude / GLM / MiniMax / Kimi / DeepSeek / OpenRouter / Custom)
- Add region selector for multi-region providers (CN / Intl)
- Add API Key input with show/hide toggle
- Add model input
- Add protocol selector for custom provider (Auto / Anthropic / OpenAI)
- Add custom API URL input
- Add "Test Connection" button with loading / success / error states
- Add collapsible error details and region-switching tip on failure
### Custom Provider — OpenAI-Compatible Support
- When selecting **Custom** provider, users can now explicitly choose **OpenAI** protocol
- The backend sends `Authorization: Bearer <key>` header instead of `x-api-key`
- URL auto-detection falls back to Anthropic-style, but user can override to OpenAI-compatible
- This enables support for any OpenAI-compatible proxy or self-hosted endpoint (e.g., Ollama, vLLM, etc.)
### Data (`src/data/aiProviders.ts`)
- Add `ApiProtocol` type and `API_PROTOCOLS` constant
- Add `defaultModel` to each provider
- Update **DeepSeek default model to `deepseek-v4-flash`** (latest available model)
### i18n
- Add 20+ `settings.ai*` keys to both `en.json` and `zh.json`
- Replace all hardcoded strings in AI settings section with `t(...)` calls
### Fixes (follow-up commit)
- Fix missing i18n keys that caused raw key display
- Fix race condition when switching providers (`setAiLoaded(false)` during async load)
- Fix frontend/backend URL resolution inconsistency for `Unknown` protocol
- Add `hasUserInteracted` guard to avoid writing defaults to DB on first mount
- Add loading spinner on provider buttons during switch
## Why this approach
- **Per-provider storage** (`key__provider`) keeps each provider's config isolated, so switching back restores previous settings automatically
- **Protocol selector** gives users explicit control when auto-detection fails. Selecting **OpenAI** switches to Bearer Token auth and `/chat/completions` endpoint, enabling any OpenAI-compatible service
- **`test_ai_connection`** uses a minimal request (`max_tokens: 1`, content `"OK"`) instead of reusing `explain_skill`, avoiding cost and latency
- **i18n-first** avoids the ad-hoc `lang === "zh"` pattern used previously
## Validation
Ran locally with Node 20 (CI target):
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` — 552 passed (13 pre-existing `themeStore` failures under Node 25, all pass under Node 20)
- `cd src-tauri && cargo test` — 284 passed
- `cd src-tauri && cargo clippy -- -D warnings`
## Tradeoffs / follow-up
- Provider configs are not yet exportable/importable as a profile
- No dropdown suggestions for model names (currently free-text input)
- `test_ai_connection` returns success on any valid `content` or `choices` response shape — extremely minimal validation
## Notes
- The `hasUserInteracted` flag prevents writing default `"claude"` / `"claude-sonnet-4-20250514"` to the DB on every first mount
- Node 25 users may see `themeStore.test.ts` failures due to `localStorage` mock differences; these do not reproduce under Node LTS (20)
- All changes are scoped to the Settings page AI Provider section
## Demo Image
<img width="954" height="343" alt="Screenshot 2026-04-25 at 00 00 18" src="https://github.com/user-attachments/assets/bb722083-4c72-42d6-98c7-605ff3fe66ca" />
<img width="929" height="464" alt="Screenshot 2026-04-25 at 00 01 13" src="https://github.com/user-attachments/assets/ea3a151f-6a8b-4ca7-9c2c-cbb71e4ea1a1" />
